### PR TITLE
Add only the last part as a tag name

### DIFF
--- a/src/app/components/annotation/annotation.controller.js
+++ b/src/app/components/annotation/annotation.controller.js
@@ -65,7 +65,7 @@
               var splitName = tagUrn.split(':');
               annotation.getTag(tagUrn).then(function (result) {
                 var tag = {
-                  'name': splitName.slice(4).join(' '),
+                  'name': splitName[splitName.length - 1],
                   'tooltip': result.name
                 };
                 tags.push(tag);


### PR DESCRIPTION
Small fix to add only the last part of the tag as the name of the Tag by request of @ldiez 